### PR TITLE
Remove a redundant statement

### DIFF
--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
@@ -245,7 +245,6 @@ public class ViewSwapper extends FrameLayout {
                     isUpdating = true;
                 }
                 adapter.destroyItem(this, ii.position, ii.object);
-                needPopulate = true;
                 if (currentItem == ii.position) {
                     newCurrItem = Math.max(0, Math.min(currentItem, adapter.getCount() - 1));
                     needPopulate = true;


### PR DESCRIPTION
I think this is a mistake in Google's original `ViewPager` implementation, which is brought here. Remove the redundant statement to make code clearer.