### PR TITLE
Don't set application properties from lib

### DIFF
--- a/adaptablebottomnavigation/src/main/AndroidManifest.xml
+++ b/adaptablebottomnavigation/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.buffer.adaptablebottomnavigation">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
Was causing this problem after adding it to my project:

```
Error:Execution failed for task ':app:processDevDebugManifest'.
> Manifest merger failed : Attribute application@label value=(@string/myAppName) from AndroidManifest.xml:11:9-51
  	is also present at [com.github.bufferapp:AdaptableBottomNavigation:2319dbccb2] AndroidManifest.xml:13:9-41 value=(@string/app_name).
  	Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:7:5-27:19 to override.
```