### PR TITLE
Fixed Issue #8 Crash in low memory conditions

### DIFF
--- a/adaptablebottomnavigation/build.gradle
+++ b/adaptablebottomnavigation/build.gradle
@@ -1,14 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 25
+        minSdkVersion 21
+        targetSdkVersion 27
         versionCode 1
-        versionName "1.0"
+        versionName "1.1"
     }
     buildTypes {
         release {
@@ -19,12 +18,12 @@ android {
 }
 
 dependencies {
-    final SUPPORT_LIBRARY_VERSION = '25.2.0'
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    final SUPPORT_LIBRARY_VERSION = '27.1.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile "com.android.support:appcompat-v7:$SUPPORT_LIBRARY_VERSION"
-    compile "com.android.support:design:$SUPPORT_LIBRARY_VERSION"
-    testCompile 'junit:junit:4.12'
+    implementation "com.android.support:appcompat-v7:$SUPPORT_LIBRARY_VERSION"
+    implementation "com.android.support:design:$SUPPORT_LIBRARY_VERSION"
+    testImplementation 'junit:junit:4.12'
 }

--- a/adaptablebottomnavigation/build.gradle
+++ b/adaptablebottomnavigation/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 15
         targetSdkVersion 27
         versionCode 1
         versionName "1.1"

--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
@@ -19,24 +19,20 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
     private ViewSwapperOnItemSelectedListener currentViewSwapperSelectedListener;
     private int selectedPosition;
 
-    public AdaptableBottomNavigationView(Context context)
-    {
+    public AdaptableBottomNavigationView(Context context) {
         super(context);
     }
 
-    public AdaptableBottomNavigationView(Context context, AttributeSet attrs)
-    {
+    public AdaptableBottomNavigationView(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 
-    public AdaptableBottomNavigationView(Context context, AttributeSet attrs, int defStyleAttr)
-    {
+    public AdaptableBottomNavigationView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
     }
 
     @Override
-    public Parcelable onSaveInstanceState()
-    {
+    public Parcelable onSaveInstanceState() {
         Parcelable superState = super.onSaveInstanceState();
         SavedState ss = new SavedState(superState);
         ss.position = selectedPosition;
@@ -44,10 +40,8 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
     }
 
     @Override
-    public void onRestoreInstanceState(Parcelable state)
-    {
-        if (!(state instanceof SavedState))
-        {
+    public void onRestoreInstanceState(Parcelable state) {
+        if (!(state instanceof SavedState)) {
             super.onRestoreInstanceState(state);
             return;
         }
@@ -58,19 +52,15 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
     }
 
     @Override
-    public void setOnNavigationItemSelectedListener(@Nullable OnNavigationItemSelectedListener listener)
-    {
+    public void setOnNavigationItemSelectedListener(@Nullable OnNavigationItemSelectedListener listener) {
         viewChangeListener = listener;
     }
 
-    public void setupWithViewSwapper(@Nullable final ViewSwapper viewSwapper)
-    {
-        if (currentViewSwapperSelectedListener != null)
-        {
+    public void setupWithViewSwapper(@Nullable final ViewSwapper viewSwapper) {
+        if (currentViewSwapperSelectedListener != null) {
             currentViewSwapperSelectedListener = null;
         }
-        if (viewSwapper != null)
-        {
+        if (viewSwapper != null) {
             currentViewSwapperSelectedListener = new ViewSwapperOnItemSelectedListener(viewSwapper);
             super.setOnNavigationItemSelectedListener(currentViewSwapperSelectedListener);
         }
@@ -81,25 +71,21 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
 
         private final ViewSwapper viewSwapper;
 
-        ViewSwapperOnItemSelectedListener(ViewSwapper viewSwapper)
-        {
+        ViewSwapperOnItemSelectedListener(ViewSwapper viewSwapper) {
             this.viewSwapper = viewSwapper;
         }
 
         @Override
-        public boolean onNavigationItemSelected(@NonNull MenuItem item)
-        {
-            for (int i = 0; i < AdaptableBottomNavigationView.this.getMenu().size(); i++)
-            {
-                if (AdaptableBottomNavigationView.this.getMenu().getItem(i).getItemId() == item.getItemId())
-                {
+        public boolean onNavigationItemSelected(@NonNull MenuItem item) {
+            for (int i = 0; i < AdaptableBottomNavigationView.this.getMenu().size(); i++) {
+                if (AdaptableBottomNavigationView.this.getMenu().getItem(
+                        i).getItemId() == item.getItemId()) {
                     selectedPosition = i;
                     viewSwapper.showItemAt(selectedPosition);
                     break;
                 }
             }
-            if (viewChangeListener != null)
-            {
+            if (viewChangeListener != null) {
                 viewChangeListener.onNavigationItemSelected(item);
             }
             return true;
@@ -113,15 +99,13 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
         ClassLoader loader;
         Parcelable superState;
 
-        public SavedState(Parcelable superState)
-        {
+        public SavedState(Parcelable superState) {
             super(EMPTY_STATE);
             this.superState = superState;
         }
 
         @Override
-        public void writeToParcel(Parcel out, int flags)
-        {
+        public void writeToParcel(Parcel out, int flags) {
             super.writeToParcel(out, flags);
             out.writeParcelable(superState, flags);
             out.writeInt(position);
@@ -129,47 +113,38 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
         }
 
         @Override
-        public String toString()
-        {
-            return "AdaptableBottomNavigationView.SavedState{"
-                    + Integer.toHexString(System.identityHashCode(this))
-                    + " position=" + position + "}";
+        public String toString() {
+            return "AdaptableBottomNavigationView.SavedState{" + Integer.toHexString(
+                    System.identityHashCode(this)) + " position=" + position + "}";
         }
 
         public static final Creator<SavedState> CREATOR = new Parcelable.ClassLoaderCreator<SavedState>()
         {
             @Override
-            public SavedState createFromParcel(Parcel parcel)
-            {
+            public SavedState createFromParcel(Parcel parcel) {
                 return null;
             }
 
             @Override
-            public SavedState[] newArray(int size)
-            {
+            public SavedState[] newArray(int size) {
                 return new SavedState[size];
             }
 
             @Override
-            public SavedState createFromParcel(Parcel parcel, ClassLoader classLoader)
-            {
-                if (Build.VERSION.SDK_INT >= 24)
-                {
+            public SavedState createFromParcel(Parcel parcel, ClassLoader classLoader) {
+                if (Build.VERSION.SDK_INT >= 24) {
                     return new SavedState(parcel, classLoader);
                 }
-                else
-                {
+                else {
                     return new SavedState(parcel);
                 }
             }
         };
 
-        SavedState(Parcel in)
-        {
+        SavedState(Parcel in) {
             super(in);
             this.superState = in.readParcelable(getClass().getClassLoader());
-            if (loader == null)
-            {
+            if (loader == null) {
                 loader = getClass().getClassLoader();
             }
             position = in.readInt();
@@ -177,12 +152,10 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
             this.loader = loader;
         }
 
-        SavedState(Parcel in, ClassLoader loader)
-        {
+        SavedState(Parcel in, ClassLoader loader) {
             super(in);
             this.superState = in.readParcelable(getClass().getClassLoader());
-            if (loader == null)
-            {
+            if (loader == null) {
                 loader = getClass().getClassLoader();
             }
             position = in.readInt();

--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
@@ -142,7 +142,7 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
         };
 
         SavedState(Parcel in, ClassLoader loader) {
-            super(in);
+            super(in, loader);
             this.superState = in.readParcelable(getClass().getClassLoader());
             if (loader == null) {
                 loader = getClass().getClassLoader();

--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
@@ -180,6 +180,7 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
         SavedState(Parcel in, ClassLoader loader)
         {
             super(in);
+            this.superState = in.readParcelable(getClass().getClassLoader());
             if (loader == null)
             {
                 loader = getClass().getClassLoader();

--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
@@ -1,6 +1,7 @@
 package org.buffer.adaptablebottomnavigation.view;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
@@ -11,26 +12,31 @@ import android.support.v4.os.ParcelableCompatCreatorCallbacks;
 import android.util.AttributeSet;
 import android.view.MenuItem;
 
-public class AdaptableBottomNavigationView extends BottomNavigationView {
+public class AdaptableBottomNavigationView extends BottomNavigationView
+{
 
     private BottomNavigationView.OnNavigationItemSelectedListener viewChangeListener;
     private ViewSwapperOnItemSelectedListener currentViewSwapperSelectedListener;
     private int selectedPosition;
 
-    public AdaptableBottomNavigationView(Context context) {
+    public AdaptableBottomNavigationView(Context context)
+    {
         super(context);
     }
 
-    public AdaptableBottomNavigationView(Context context, AttributeSet attrs) {
+    public AdaptableBottomNavigationView(Context context, AttributeSet attrs)
+    {
         super(context, attrs);
     }
 
-    public AdaptableBottomNavigationView(Context context, AttributeSet attrs, int defStyleAttr) {
+    public AdaptableBottomNavigationView(Context context, AttributeSet attrs, int defStyleAttr)
+    {
         super(context, attrs, defStyleAttr);
     }
 
     @Override
-    public Parcelable onSaveInstanceState() {
+    public Parcelable onSaveInstanceState()
+    {
         Parcelable superState = super.onSaveInstanceState();
         SavedState ss = new SavedState(superState);
         ss.position = selectedPosition;
@@ -38,8 +44,10 @@ public class AdaptableBottomNavigationView extends BottomNavigationView {
     }
 
     @Override
-    public void onRestoreInstanceState(Parcelable state) {
-        if (!(state instanceof SavedState)) {
+    public void onRestoreInstanceState(Parcelable state)
+    {
+        if (!(state instanceof SavedState))
+        {
             super.onRestoreInstanceState(state);
             return;
         }
@@ -50,86 +58,130 @@ public class AdaptableBottomNavigationView extends BottomNavigationView {
     }
 
     @Override
-    public void setOnNavigationItemSelectedListener(
-            @Nullable OnNavigationItemSelectedListener listener) {
+    public void setOnNavigationItemSelectedListener(@Nullable OnNavigationItemSelectedListener listener)
+    {
         viewChangeListener = listener;
     }
 
-    public void setupWithViewSwapper(@Nullable final ViewSwapper viewSwapper) {
-        if (currentViewSwapperSelectedListener != null) {
+    public void setupWithViewSwapper(@Nullable final ViewSwapper viewSwapper)
+    {
+        if (currentViewSwapperSelectedListener != null)
+        {
             currentViewSwapperSelectedListener = null;
         }
-        if (viewSwapper != null) {
+        if (viewSwapper != null)
+        {
             currentViewSwapperSelectedListener = new ViewSwapperOnItemSelectedListener(viewSwapper);
             super.setOnNavigationItemSelectedListener(currentViewSwapperSelectedListener);
         }
     }
 
-    public class ViewSwapperOnItemSelectedListener implements
-            BottomNavigationView.OnNavigationItemSelectedListener {
+    public class ViewSwapperOnItemSelectedListener implements BottomNavigationView.OnNavigationItemSelectedListener
+    {
 
         private final ViewSwapper viewSwapper;
 
-        ViewSwapperOnItemSelectedListener(ViewSwapper viewSwapper) {
+        ViewSwapperOnItemSelectedListener(ViewSwapper viewSwapper)
+        {
             this.viewSwapper = viewSwapper;
         }
 
         @Override
-        public boolean onNavigationItemSelected(@NonNull MenuItem item) {
-            for (int i = 0; i < AdaptableBottomNavigationView.this.getMenu().size(); i++) {
-                if (AdaptableBottomNavigationView.this.getMenu().getItem(i).getItemId() ==
-                        item.getItemId()) {
+        public boolean onNavigationItemSelected(@NonNull MenuItem item)
+        {
+            for (int i = 0; i < AdaptableBottomNavigationView.this.getMenu().size(); i++)
+            {
+                if (AdaptableBottomNavigationView.this.getMenu().getItem(i).getItemId() == item.getItemId())
+                {
                     selectedPosition = i;
                     viewSwapper.showItemAt(selectedPosition);
                     break;
                 }
             }
-            if (viewChangeListener != null)  {
+            if (viewChangeListener != null)
+            {
                 viewChangeListener.onNavigationItemSelected(item);
             }
             return true;
         }
     }
 
-    public static class SavedState extends BaseSavedState {
+    public static class SavedState extends BaseSavedState
+    {
         int position;
         Parcelable viewState;
         ClassLoader loader;
+        Parcelable superState;
 
-        public SavedState(Parcelable superState) {
-            super(superState);
+        public SavedState(Parcelable superState)
+        {
+            super(EMPTY_STATE);
+            this.superState = superState;
         }
 
         @Override
-        public void writeToParcel(Parcel out, int flags) {
+        public void writeToParcel(Parcel out, int flags)
+        {
             super.writeToParcel(out, flags);
+            out.writeParcelable(superState, flags);
             out.writeInt(position);
             out.writeParcelable(viewState, flags);
         }
 
         @Override
-        public String toString() {
-            return "ViewSwapper.SavedState{"
+        public String toString()
+        {
+            return "AdaptableBottomNavigationView.SavedState{"
                     + Integer.toHexString(System.identityHashCode(this))
                     + " position=" + position + "}";
         }
 
-        public static final Creator<ViewSwapper.SavedState> CREATOR
-                = ParcelableCompat.newCreator(new ParcelableCompatCreatorCallbacks<ViewSwapper.SavedState>() {
+        public static final Creator<SavedState> CREATOR = new Parcelable.ClassLoaderCreator<SavedState>()
+        {
             @Override
-            public ViewSwapper.SavedState createFromParcel(Parcel in, ClassLoader loader) {
-                return new ViewSwapper.SavedState(in, loader);
+            public SavedState createFromParcel(Parcel parcel)
+            {
+                return null;
             }
 
             @Override
-            public ViewSwapper.SavedState[] newArray(int size) {
-                return new ViewSwapper.SavedState[size];
+            public SavedState[] newArray(int size)
+            {
+                return new SavedState[size];
             }
-        });
 
-        SavedState(Parcel in, ClassLoader loader) {
+            @Override
+            public SavedState createFromParcel(Parcel parcel, ClassLoader classLoader)
+            {
+                if (Build.VERSION.SDK_INT >= 24)
+                {
+                    return new SavedState(parcel, classLoader);
+                }
+                else
+                {
+                    return new SavedState(parcel);
+                }
+            }
+        };
+
+        SavedState(Parcel in)
+        {
             super(in);
-            if (loader == null) {
+            this.superState = in.readParcelable(getClass().getClassLoader());
+            if (loader == null)
+            {
+                loader = getClass().getClassLoader();
+            }
+            position = in.readInt();
+            viewState = in.readParcelable(loader);
+            this.loader = loader;
+        }
+
+        SavedState(Parcel in, ClassLoader loader)
+        {
+            super(in);
+            if (loader == null)
+            {
                 loader = getClass().getClassLoader();
             }
             position = in.readInt();
@@ -137,5 +189,4 @@ public class AdaptableBottomNavigationView extends BottomNavigationView {
             this.loader = loader;
         }
     }
-
 }

--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/AdaptableBottomNavigationView.java
@@ -141,7 +141,7 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
             }
         };
 
-        SavedState(Parcel in) {
+        SavedState(Parcel in, ClassLoader loader) {
             super(in);
             this.superState = in.readParcelable(getClass().getClassLoader());
             if (loader == null) {
@@ -152,7 +152,7 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
             this.loader = loader;
         }
 
-        SavedState(Parcel in, ClassLoader loader) {
+        SavedState(Parcel in) {
             super(in);
             this.superState = in.readParcelable(getClass().getClassLoader());
             if (loader == null) {
@@ -160,7 +160,6 @@ public class AdaptableBottomNavigationView extends BottomNavigationView
             }
             position = in.readInt();
             viewState = in.readParcelable(loader);
-            this.loader = loader;
         }
     }
 }

--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
@@ -212,7 +212,6 @@ public class ViewSwapper extends FrameLayout
             }
             position = in.readInt();
             adapterState = in.readParcelable(loader);
-            this.loader = loader;
         }
     }
 

--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
@@ -31,63 +31,51 @@ public class ViewSwapper extends FrameLayout
     private static final Comparator<ItemInfo> COMPARATOR = new Comparator<ItemInfo>()
     {
         @Override
-        public int compare(ItemInfo lhs, ItemInfo rhs)
-        {
+        public int compare(ItemInfo lhs, ItemInfo rhs) {
             return lhs.position - rhs.position;
         }
     };
 
     private int currentItem;
 
-    public ViewSwapper(Context context)
-    {
+    public ViewSwapper(Context context) {
         super(context);
     }
 
-    public ViewSwapper(Context context, AttributeSet attrs)
-    {
+    public ViewSwapper(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 
-    public ViewSwapper(Context context, AttributeSet attrs, int defStyleAttr)
-    {
+    public ViewSwapper(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public ViewSwapper(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes)
-    {
+    public ViewSwapper(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
     }
 
     @Override
-    protected void onAttachedToWindow()
-    {
+    protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        if (currentRestoredItem < 0 && adapter != null && adapter.getCount() > 0)
-        {
+        if (currentRestoredItem < 0 && adapter != null && adapter.getCount() > 0) {
             showItemInternal(0);
         }
     }
 
-    public ViewSwapperAdapter getAdapter()
-    {
+    public ViewSwapperAdapter getAdapter() {
         return this.adapter;
     }
 
-    public int getCurrentItem()
-    {
+    public int getCurrentItem() {
         return currentItem;
     }
 
-    public void setAdapter(ViewSwapperAdapter adapter)
-    {
-        if (adapter != null)
-        {
+    public void setAdapter(ViewSwapperAdapter adapter) {
+        if (adapter != null) {
             adapter.setViewSwapperObserver(null);
             adapter.startUpdate(this);
-            for (int i = 0; i < items.size(); i++)
-            {
+            for (int i = 0; i < items.size(); i++) {
                 final ItemInfo ii = items.get(i);
                 adapter.destroyItem(this, ii.position, ii.object);
             }
@@ -97,19 +85,15 @@ public class ViewSwapper extends FrameLayout
 
         this.adapter = adapter;
 
-        if (adapter != null)
-        {
-            if (observer == null)
-            {
+        if (adapter != null) {
+            if (observer == null) {
                 observer = new PagerObserver();
             }
-            for (int i = 0; i < this.adapter.getCount(); i++)
-            {
+            for (int i = 0; i < this.adapter.getCount(); i++) {
                 addNewItem(i);
             }
             adapter.registerDataSetObserver(observer);
-            if (currentRestoredItem >= 0)
-            {
+            if (currentRestoredItem >= 0) {
                 adapter.restoreState(restoredAdapterState, restoredClassLoader);
                 showItemInternal(currentRestoredItem);
                 currentRestoredItem = -1;
@@ -119,42 +103,34 @@ public class ViewSwapper extends FrameLayout
         }
     }
 
-    ItemInfo addNewItem(int position)
-    {
+    ItemInfo addNewItem(int position) {
         ItemInfo ii = new ItemInfo();
         ii.position = position;
-        if (position < 0 || position >= items.size())
-        {
+        if (position < 0 || position >= items.size()) {
             items.add(ii);
         }
-        else
-        {
+        else {
             items.add(position, ii);
         }
         return ii;
     }
 
-    public void showItemAt(int position)
-    {
-        if (items.get(position) == null)
-        {
+    public void showItemAt(int position) {
+        if (items.get(position) == null) {
             addNewItem(position);
         }
 
-        if (currentItem == position)
-        {
+        if (currentItem == position) {
             this.adapter.clearItem(this, currentItem, items.get(currentItem).object);
         }
-        else if (this.adapter.getCount() > 0)
-        {
+        else if (this.adapter.getCount() > 0) {
             this.adapter.destroyItem(this, currentItem, items.get(currentItem).object);
         }
 
         showItemInternal(position);
     }
 
-    private void showItemInternal(int position)
-    {
+    private void showItemInternal(int position) {
         currentItem = position;
         items.get(position).object = this.adapter.instantiateItem(this, position);
         this.adapter.finishUpdate(this);
@@ -175,15 +151,13 @@ public class ViewSwapper extends FrameLayout
         ClassLoader loader;
         Parcelable superState;
 
-        public SavedState(Parcelable superState)
-        {
+        public SavedState(Parcelable superState) {
             super(EMPTY_STATE);
             this.superState = superState;
         }
 
         @Override
-        public void writeToParcel(Parcel out, int flags)
-        {
+        public void writeToParcel(Parcel out, int flags) {
             super.writeToParcel(out, flags);
             out.writeParcelable(superState, flags);
             out.writeInt(position);
@@ -191,45 +165,38 @@ public class ViewSwapper extends FrameLayout
         }
 
         @Override
-        public String toString()
-        {
-            return "FragmentPager.SavedState{" + Integer.toHexString(System.identityHashCode(this)) + " position=" + position + "}";
+        public String toString() {
+            return "FragmentPager.SavedState{" + Integer.toHexString(
+                    System.identityHashCode(this)) + " position=" + position + "}";
         }
 
         public static final Creator<SavedState> CREATOR = new Parcelable.ClassLoaderCreator<SavedState>()
         {
             @Override
-            public SavedState createFromParcel(Parcel parcel)
-            {
+            public SavedState createFromParcel(Parcel parcel) {
                 return new SavedState(parcel);
             }
 
             @Override
-            public SavedState[] newArray(int size)
-            {
+            public SavedState[] newArray(int size) {
                 return new SavedState[size];
             }
 
             @Override
-            public SavedState createFromParcel(Parcel parcel, ClassLoader classLoader)
-            {
-                if (Build.VERSION.SDK_INT >= 24)
-                {
+            public SavedState createFromParcel(Parcel parcel, ClassLoader classLoader) {
+                if (Build.VERSION.SDK_INT >= 24) {
                     return new SavedState(parcel, classLoader);
                 }
-                else
-                {
+                else {
                     return new SavedState(parcel);
                 }
             }
         };
 
-        SavedState(Parcel in, ClassLoader loader)
-        {
+        SavedState(Parcel in, ClassLoader loader) {
             super(in, loader);
             this.superState = in.readParcelable(getClass().getClassLoader());
-            if (loader == null)
-            {
+            if (loader == null) {
                 loader = getClass().getClassLoader();
             }
             position = in.readInt();
@@ -237,12 +204,10 @@ public class ViewSwapper extends FrameLayout
             this.loader = loader;
         }
 
-        SavedState(Parcel in)
-        {
+        SavedState(Parcel in) {
             super(in);
             this.superState = in.readParcelable(getClass().getClassLoader());
-            if (loader == null)
-            {
+            if (loader == null) {
                 loader = getClass().getClassLoader();
             }
             position = in.readInt();
@@ -252,35 +217,29 @@ public class ViewSwapper extends FrameLayout
     }
 
     @Override
-    public Parcelable onSaveInstanceState()
-    {
+    public Parcelable onSaveInstanceState() {
         Parcelable superState = super.onSaveInstanceState();
         SavedState ss = new SavedState(superState);
         ss.position = currentItem;
-        if (adapter != null)
-        {
+        if (adapter != null) {
             ss.adapterState = adapter.saveState();
         }
         return ss;
     }
 
     @Override
-    public void onRestoreInstanceState(Parcelable state)
-    {
-        if (!(state instanceof SavedState))
-        {
+    public void onRestoreInstanceState(Parcelable state) {
+        if (!(state instanceof SavedState)) {
             super.onRestoreInstanceState(state);
             return;
         }
         SavedState ss = (SavedState) state;
         super.onRestoreInstanceState(ss.getSuperState());
-        if (adapter != null)
-        {
+        if (adapter != null) {
             adapter.restoreState(ss.adapterState, ss.loader);
             showItemInternal(ss.position >= 0 ? ss.position : 0);
         }
-        else
-        {
+        else {
             restoredAdapterState = ss.adapterState;
             restoredClassLoader = ss.loader;
         }
@@ -290,66 +249,54 @@ public class ViewSwapper extends FrameLayout
     private class PagerObserver extends DataSetObserver
     {
         @Override
-        public void onChanged()
-        {
+        public void onChanged() {
             dataSetChanged();
         }
 
         @Override
-        public void onInvalidated()
-        {
+        public void onInvalidated() {
             dataSetChanged();
         }
     }
 
-    void dataSetChanged()
-    {
+    void dataSetChanged() {
         boolean needPopulate = items.size() < adapter.getCount();
         int newCurrItem = currentItem;
         boolean isUpdating = false;
-        for (int i = 0; i < items.size(); i++)
-        {
+        for (int i = 0; i < items.size(); i++) {
             final ItemInfo ii = items.get(i);
             final int newPos = adapter.getItemPosition(ii.object);
-            if (newPos == ViewSwapperAdapter.POSITION_UNCHANGED)
-            {
+            if (newPos == ViewSwapperAdapter.POSITION_UNCHANGED) {
                 continue;
             }
-            if (newPos == ViewSwapperAdapter.POSITION_NONE)
-            {
+            if (newPos == ViewSwapperAdapter.POSITION_NONE) {
                 items.remove(i);
                 i--;
-                if (!isUpdating)
-                {
+                if (!isUpdating) {
                     adapter.startUpdate(this);
                     isUpdating = true;
                 }
                 adapter.destroyItem(this, ii.position, ii.object);
                 needPopulate = true;
-                if (currentItem == ii.position)
-                {
+                if (currentItem == ii.position) {
                     newCurrItem = Math.max(0, Math.min(currentItem, adapter.getCount() - 1));
                     needPopulate = true;
                 }
                 continue;
             }
-            if (ii.position != newPos)
-            {
-                if (ii.position == currentItem)
-                {
+            if (ii.position != newPos) {
+                if (ii.position == currentItem) {
                     newCurrItem = newPos;
                 }
                 ii.position = newPos;
                 needPopulate = true;
             }
         }
-        if (isUpdating)
-        {
+        if (isUpdating) {
             adapter.finishUpdate(this);
         }
         Collections.sort(items, COMPARATOR);
-        if (needPopulate)
-        {
+        if (needPopulate) {
             showItemInternal(newCurrItem);
             requestLayout();
         }

--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
@@ -227,6 +227,7 @@ public class ViewSwapper extends FrameLayout
         SavedState(Parcel in, ClassLoader loader)
         {
             super(in, loader);
+            this.superState = in.readParcelable(getClass().getClassLoader());
             if (loader == null)
             {
                 loader = getClass().getClassLoader();

--- a/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
+++ b/adaptablebottomnavigation/src/main/java/org/buffer/adaptablebottomnavigation/view/ViewSwapper.java
@@ -18,8 +18,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 
-public class ViewSwapper extends FrameLayout {
-
+public class ViewSwapper extends FrameLayout
+{
     private final ArrayList<ItemInfo> items = new ArrayList<>();
 
     private ViewSwapperAdapter adapter;
@@ -28,53 +28,66 @@ public class ViewSwapper extends FrameLayout {
     private ClassLoader restoredClassLoader = null;
     private PagerObserver observer;
 
-    private static final Comparator<ItemInfo> COMPARATOR = new Comparator<ItemInfo>() {
+    private static final Comparator<ItemInfo> COMPARATOR = new Comparator<ItemInfo>()
+    {
         @Override
-        public int compare(ItemInfo lhs, ItemInfo rhs) {
+        public int compare(ItemInfo lhs, ItemInfo rhs)
+        {
             return lhs.position - rhs.position;
         }
     };
 
     private int currentItem;
 
-    public ViewSwapper(Context context) {
+    public ViewSwapper(Context context)
+    {
         super(context);
     }
 
-    public ViewSwapper(Context context, AttributeSet attrs) {
+    public ViewSwapper(Context context, AttributeSet attrs)
+    {
         super(context, attrs);
     }
 
-    public ViewSwapper(Context context, AttributeSet attrs, int defStyleAttr) {
+    public ViewSwapper(Context context, AttributeSet attrs, int defStyleAttr)
+    {
         super(context, attrs, defStyleAttr);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public ViewSwapper(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    public ViewSwapper(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes)
+    {
         super(context, attrs, defStyleAttr, defStyleRes);
     }
 
     @Override
-    protected void onAttachedToWindow() {
+    protected void onAttachedToWindow()
+    {
         super.onAttachedToWindow();
-        if (currentRestoredItem < 0 && adapter != null && adapter.getCount() > 0) {
+        if (currentRestoredItem < 0 && adapter != null && adapter.getCount() > 0)
+        {
             showItemInternal(0);
         }
     }
 
-    public ViewSwapperAdapter getAdapter() {
+    public ViewSwapperAdapter getAdapter()
+    {
         return this.adapter;
     }
 
-    public int getCurrentItem() {
+    public int getCurrentItem()
+    {
         return currentItem;
     }
 
-    public void setAdapter(ViewSwapperAdapter adapter) {
-        if (adapter != null) {
+    public void setAdapter(ViewSwapperAdapter adapter)
+    {
+        if (adapter != null)
+        {
             adapter.setViewSwapperObserver(null);
             adapter.startUpdate(this);
-            for (int i = 0; i < items.size(); i++) {
+            for (int i = 0; i < items.size(); i++)
+            {
                 final ItemInfo ii = items.get(i);
                 adapter.destroyItem(this, ii.position, ii.object);
             }
@@ -84,15 +97,19 @@ public class ViewSwapper extends FrameLayout {
 
         this.adapter = adapter;
 
-        if (adapter != null) {
-            if (observer == null) {
+        if (adapter != null)
+        {
+            if (observer == null)
+            {
                 observer = new PagerObserver();
             }
-            for (int i = 0; i < this.adapter.getCount(); i++) {
+            for (int i = 0; i < this.adapter.getCount(); i++)
+            {
                 addNewItem(i);
             }
             adapter.registerDataSetObserver(observer);
-            if (currentRestoredItem >= 0) {
+            if (currentRestoredItem >= 0)
+            {
                 adapter.restoreState(restoredAdapterState, restoredClassLoader);
                 showItemInternal(currentRestoredItem);
                 currentRestoredItem = -1;
@@ -102,32 +119,42 @@ public class ViewSwapper extends FrameLayout {
         }
     }
 
-    ItemInfo addNewItem(int position) {
+    ItemInfo addNewItem(int position)
+    {
         ItemInfo ii = new ItemInfo();
         ii.position = position;
-        if (position < 0 || position >= items.size()) {
+        if (position < 0 || position >= items.size())
+        {
             items.add(ii);
-        } else {
+        }
+        else
+        {
             items.add(position, ii);
         }
         return ii;
     }
 
-    public void showItemAt(int position) {
-        if (items.get(position) == null) {
+    public void showItemAt(int position)
+    {
+        if (items.get(position) == null)
+        {
             addNewItem(position);
         }
 
-        if (currentItem == position) {
+        if (currentItem == position)
+        {
             this.adapter.clearItem(this, currentItem, items.get(currentItem).object);
-        } else if (this.adapter.getCount() > 0) {
+        }
+        else if (this.adapter.getCount() > 0)
+        {
             this.adapter.destroyItem(this, currentItem, items.get(currentItem).object);
         }
 
         showItemInternal(position);
     }
 
-    private void showItemInternal(int position) {
+    private void showItemInternal(int position)
+    {
         currentItem = position;
         items.get(position).object = this.adapter.instantiateItem(this, position);
         this.adapter.finishUpdate(this);
@@ -138,46 +165,83 @@ public class ViewSwapper extends FrameLayout {
      * if you are creating a sublass of ViewPager that must save its own
      * state, in which case it should implement a subclass of this which
      * contains that state.
+     * <p>
+     * Changed this class to solve https://github.com/bufferapp/AdaptableBottomNavigation/issues/8
      */
-    public static class SavedState extends BaseSavedState {
+    public static class SavedState extends BaseSavedState
+    {
         int position;
         Parcelable adapterState;
         ClassLoader loader;
+        Parcelable superState;
 
-        public SavedState(Parcelable superState) {
-            super(superState);
+        public SavedState(Parcelable superState)
+        {
+            super(EMPTY_STATE);
+            this.superState = superState;
         }
 
         @Override
-        public void writeToParcel(Parcel out, int flags) {
+        public void writeToParcel(Parcel out, int flags)
+        {
             super.writeToParcel(out, flags);
+            out.writeParcelable(superState, flags);
             out.writeInt(position);
             out.writeParcelable(adapterState, flags);
         }
 
         @Override
-        public String toString() {
-            return "FragmentPager.SavedState{"
-                    + Integer.toHexString(System.identityHashCode(this))
-                    + " position=" + position + "}";
+        public String toString()
+        {
+            return "FragmentPager.SavedState{" + Integer.toHexString(System.identityHashCode(this)) + " position=" + position + "}";
         }
 
-        public static final Creator<SavedState> CREATOR
-                = ParcelableCompat.newCreator(new ParcelableCompatCreatorCallbacks<SavedState>() {
+        public static final Creator<SavedState> CREATOR = new Parcelable.ClassLoaderCreator<SavedState>()
+        {
             @Override
-            public SavedState createFromParcel(Parcel in, ClassLoader loader) {
-                return new SavedState(in, loader);
+            public SavedState createFromParcel(Parcel parcel)
+            {
+                return new SavedState(parcel);
             }
 
             @Override
-            public SavedState[] newArray(int size) {
+            public SavedState[] newArray(int size)
+            {
                 return new SavedState[size];
             }
-        });
 
-        SavedState(Parcel in, ClassLoader loader) {
+            @Override
+            public SavedState createFromParcel(Parcel parcel, ClassLoader classLoader)
+            {
+                if (Build.VERSION.SDK_INT >= 24)
+                {
+                    return new SavedState(parcel, classLoader);
+                }
+                else
+                {
+                    return new SavedState(parcel);
+                }
+            }
+        };
+
+        SavedState(Parcel in, ClassLoader loader)
+        {
+            super(in, loader);
+            if (loader == null)
+            {
+                loader = getClass().getClassLoader();
+            }
+            position = in.readInt();
+            adapterState = in.readParcelable(loader);
+            this.loader = loader;
+        }
+
+        SavedState(Parcel in)
+        {
             super(in);
-            if (loader == null) {
+            this.superState = in.readParcelable(getClass().getClassLoader());
+            if (loader == null)
+            {
                 loader = getClass().getClassLoader();
             }
             position = in.readInt();
@@ -187,84 +251,104 @@ public class ViewSwapper extends FrameLayout {
     }
 
     @Override
-    public Parcelable onSaveInstanceState() {
+    public Parcelable onSaveInstanceState()
+    {
         Parcelable superState = super.onSaveInstanceState();
         SavedState ss = new SavedState(superState);
         ss.position = currentItem;
-        if (adapter != null) {
+        if (adapter != null)
+        {
             ss.adapterState = adapter.saveState();
         }
         return ss;
     }
 
     @Override
-    public void onRestoreInstanceState(Parcelable state) {
-        if (!(state instanceof SavedState)) {
+    public void onRestoreInstanceState(Parcelable state)
+    {
+        if (!(state instanceof SavedState))
+        {
             super.onRestoreInstanceState(state);
             return;
         }
         SavedState ss = (SavedState) state;
         super.onRestoreInstanceState(ss.getSuperState());
-        if (adapter != null) {
+        if (adapter != null)
+        {
             adapter.restoreState(ss.adapterState, ss.loader);
             showItemInternal(ss.position >= 0 ? ss.position : 0);
-        } else {
+        }
+        else
+        {
             restoredAdapterState = ss.adapterState;
             restoredClassLoader = ss.loader;
         }
         currentRestoredItem = ss.position;
     }
 
-    private class PagerObserver extends DataSetObserver {
+    private class PagerObserver extends DataSetObserver
+    {
         @Override
-        public void onChanged() {
+        public void onChanged()
+        {
             dataSetChanged();
         }
 
         @Override
-        public void onInvalidated() {
+        public void onInvalidated()
+        {
             dataSetChanged();
         }
     }
 
-    void dataSetChanged() {
+    void dataSetChanged()
+    {
         boolean needPopulate = items.size() < adapter.getCount();
         int newCurrItem = currentItem;
         boolean isUpdating = false;
-        for (int i = 0; i < items.size(); i++) {
+        for (int i = 0; i < items.size(); i++)
+        {
             final ItemInfo ii = items.get(i);
             final int newPos = adapter.getItemPosition(ii.object);
-            if (newPos == ViewSwapperAdapter.POSITION_UNCHANGED) {
+            if (newPos == ViewSwapperAdapter.POSITION_UNCHANGED)
+            {
                 continue;
             }
-            if (newPos == ViewSwapperAdapter.POSITION_NONE) {
+            if (newPos == ViewSwapperAdapter.POSITION_NONE)
+            {
                 items.remove(i);
                 i--;
-                if (!isUpdating) {
+                if (!isUpdating)
+                {
                     adapter.startUpdate(this);
                     isUpdating = true;
                 }
                 adapter.destroyItem(this, ii.position, ii.object);
                 needPopulate = true;
-                if (currentItem == ii.position) {
+                if (currentItem == ii.position)
+                {
                     newCurrItem = Math.max(0, Math.min(currentItem, adapter.getCount() - 1));
                     needPopulate = true;
                 }
                 continue;
             }
-            if (ii.position != newPos) {
-                if (ii.position == currentItem) {
+            if (ii.position != newPos)
+            {
+                if (ii.position == currentItem)
+                {
                     newCurrItem = newPos;
                 }
                 ii.position = newPos;
                 needPopulate = true;
             }
         }
-        if (isUpdating) {
+        if (isUpdating)
+        {
             adapter.finishUpdate(this);
         }
         Collections.sort(items, COMPARATOR);
-        if (needPopulate) {
+        if (needPopulate)
+        {
             showItemInternal(newCurrItem);
             requestLayout();
         }

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Sat Aug 18 13:05:47 EET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
     defaultConfig {
         applicationId "org.buffer.simplebottomnavigation.sample"
-        minSdkVersion 15
-        targetSdkVersion 25
+        minSdkVersion 21
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -20,11 +19,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
-    compile 'com.android.support:appcompat-v7:25.2.0'
-    testCompile 'junit:junit:4.12'
-    compile project(path: ':adaptablebottomnavigation')
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    testImplementation 'junit:junit:4.12'
+    implementation project(':adaptablebottomnavigation')
+    implementation 'com.android.support:design:27.1.1'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "org.buffer.simplebottomnavigation.sample"
-        minSdkVersion 21
+        minSdkVersion 15
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/sample/src/main/java/org/buffer/adaptablebottomnavigation/sample/ImageFragment.java
+++ b/sample/src/main/java/org/buffer/adaptablebottomnavigation/sample/ImageFragment.java
@@ -34,7 +34,7 @@ public class ImageFragment extends Fragment {
                              @Nullable Bundle savedInstanceState) {
         View fragmentView = inflater.inflate(R.layout.fragment_image, container, false);
 
-        ImageView iconImage = (ImageView) fragmentView.findViewById(R.id.image_icon);
+        ImageView iconImage = fragmentView.findViewById(R.id.image_icon);
         iconImage.setImageResource(imageRes);
 
         return fragmentView;

--- a/sample/src/main/java/org/buffer/adaptablebottomnavigation/sample/MainActivity.java
+++ b/sample/src/main/java/org/buffer/adaptablebottomnavigation/sample/MainActivity.java
@@ -1,25 +1,26 @@
 package org.buffer.adaptablebottomnavigation.sample;
 
+
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
 import org.buffer.adaptablebottomnavigation.view.AdaptableBottomNavigationView;
 import org.buffer.adaptablebottomnavigation.view.ViewSwapper;
 
-public class MainActivity extends AppCompatActivity {
-
+public class MainActivity extends AppCompatActivity
+{
     private AdaptableBottomNavigationView bottomNavigationView;
     private ViewSwapperAdapter viewSwapperAdapter;
     private ViewSwapper viewSwapper;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState)
+    {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        bottomNavigationView = (AdaptableBottomNavigationView)
-                findViewById(R.id.view_bottom_navigation);
-        viewSwapper = (ViewSwapper) findViewById(R.id.view_swapper);
+        bottomNavigationView = findViewById(R.id.view_bottom_navigation);
+        viewSwapper = findViewById(R.id.view_swapper);
         viewSwapperAdapter = new ViewSwapperAdapter(getSupportFragmentManager());
 
         viewSwapper.setAdapter(viewSwapperAdapter);

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -9,7 +10,7 @@
         android:id="@+id/view_swapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/view_bottom_navigation" />
+        android:layout_above="@+id/view_bottom_navigation"/>
 
     <org.buffer.adaptablebottomnavigation.view.AdaptableBottomNavigationView
         android:id="@+id/view_bottom_navigation"
@@ -20,6 +21,6 @@
         app:itemBackground="@color/colorPrimary"
         app:itemIconTint="@drawable/selector_menu"
         app:itemTextColor="@drawable/selector_menu"
-        app:menu="@menu/main" />
+        app:menu="@menu/main"/>
 
 </RelativeLayout>


### PR DESCRIPTION
For api 24 and later added SavedState constructor that takes a ClassLoader parameter, for lower Android versions manually saving superstate so unmarshaling does not crash. 